### PR TITLE
Set minimum version of omp

### DIFF
--- a/ppx_tools_versioned.opam
+++ b/ppx_tools_versioned.opam
@@ -16,6 +16,6 @@ build: [
 build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 depends: [
   "jbuilder" {build & >= "1.0+beta17"}
-  "ocaml-migrate-parsetree" { >= "0.4" }
+  "ocaml-migrate-parsetree" { >= "1.0.10" }
 ]
 available: ocaml-version >= "4.02.0"


### PR DESCRIPTION
This is the minimum version to use the 406 parsetree I believe. @let-def a release would be appreciated as well