### PR TITLE
open Migrate_parsetree.Ast_* instead of Ast_*

### DIFF
--- a/ast_convenience_402.ml
+++ b/ast_convenience_402.ml
@@ -1,4 +1,4 @@
-open Ast_402
+open Migrate_parsetree.Ast_402
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_402.mli
+++ b/ast_convenience_402.mli
@@ -1,4 +1,4 @@
-open Ast_402
+open Migrate_parsetree.Ast_402
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_403.ml
+++ b/ast_convenience_403.ml
@@ -1,4 +1,4 @@
-open Ast_403
+open Migrate_parsetree.Ast_403
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_403.mli
+++ b/ast_convenience_403.mli
@@ -1,4 +1,4 @@
-open Ast_403
+open Migrate_parsetree.Ast_403
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_404.ml
+++ b/ast_convenience_404.ml
@@ -1,4 +1,4 @@
-open Ast_404
+open Migrate_parsetree.Ast_404
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)
@@ -27,18 +27,18 @@ module Label = struct
 
 end
 
-module Constant = struct 
+module Constant = struct
   type t = Parsetree.constant =
-     Pconst_integer of string * char option 
-   | Pconst_char of char 
-   | Pconst_string of string * string option 
-   | Pconst_float of string * char option 
+     Pconst_integer of string * char option
+   | Pconst_char of char
+   | Pconst_string of string * string option
+   | Pconst_float of string * char option
 
-  let of_constant x = x 
+  let of_constant x = x
 
   let to_constant x = x
 
-end 
+end
 
 let may_tuple ?loc tup = function
   | [] -> None

--- a/ast_convenience_404.mli
+++ b/ast_convenience_404.mli
@@ -1,4 +1,4 @@
-open Ast_404
+open Migrate_parsetree.Ast_404
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)
@@ -28,16 +28,16 @@ module Label : sig
 
 end
 
-(** {2 Provides a unified abstraction over differences in Parsetree.constant and Asttypes.constant 
+(** {2 Provides a unified abstraction over differences in Parsetree.constant and Asttypes.constant
  * types defined in ocaml 4.03 and 4.02 respectively}*)
-module Constant : sig 
+module Constant : sig
   type t = Parsetree.constant =
-     Pconst_integer of string * char option 
-   | Pconst_char of char 
-   | Pconst_string of string * string option 
-   | Pconst_float of string * char option 
- 
-  (** Convert Asttypes.constant to Constant.t *) 
+     Pconst_integer of string * char option
+   | Pconst_char of char
+   | Pconst_string of string * string option
+   | Pconst_float of string * char option
+
+  (** Convert Asttypes.constant to Constant.t *)
   val of_constant : Parsetree.constant -> t
 
   (** Convert Constant.t to Asttypes.constant *)

--- a/ast_convenience_405.ml
+++ b/ast_convenience_405.ml
@@ -1,4 +1,4 @@
-open Ast_405
+open Migrate_parsetree.Ast_405
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_405.mli
+++ b/ast_convenience_405.mli
@@ -1,4 +1,4 @@
-open Ast_405
+open Migrate_parsetree.Ast_405
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_406.ml
+++ b/ast_convenience_406.ml
@@ -1,4 +1,4 @@
-open Ast_406
+open Migrate_parsetree.Ast_406
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_406.mli
+++ b/ast_convenience_406.mli
@@ -1,4 +1,4 @@
-open Ast_406
+open Migrate_parsetree.Ast_406
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_407.ml
+++ b/ast_convenience_407.ml
@@ -1,4 +1,4 @@
-open Ast_407
+open Migrate_parsetree.Ast_407
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_convenience_407.mli
+++ b/ast_convenience_407.mli
@@ -1,4 +1,4 @@
-open Ast_407
+open Migrate_parsetree.Ast_407
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_lifter_402.ml
+++ b/ast_lifter_402.ml
@@ -1,4 +1,4 @@
-open Ast_402
+open Migrate_parsetree.Ast_402
 
 class virtual ['res] lifter =
   object (this)

--- a/ast_lifter_403.ml
+++ b/ast_lifter_403.ml
@@ -1,4 +1,4 @@
-open Ast_403
+open Migrate_parsetree.Ast_403
 
 class virtual ['res] lifter =
   object (this)

--- a/ast_lifter_404.ml
+++ b/ast_lifter_404.ml
@@ -1,4 +1,4 @@
-open Ast_404
+open Migrate_parsetree.Ast_404
 
 class virtual ['res] lifter =
   object (this)

--- a/ast_lifter_405.ml
+++ b/ast_lifter_405.ml
@@ -1,4 +1,4 @@
-open Ast_405
+open Migrate_parsetree.Ast_405
 
 class virtual ['res] lifter =
   object (this)

--- a/ast_lifter_406.ml
+++ b/ast_lifter_406.ml
@@ -1,4 +1,4 @@
-open Ast_406
+open Migrate_parsetree.Ast_406
 
 class virtual ['res] lifter =
   object (this)

--- a/ast_lifter_407.ml
+++ b/ast_lifter_407.ml
@@ -1,4 +1,4 @@
-open Ast_407
+open Migrate_parsetree.Ast_407
 
 class virtual ['res] lifter =
   object (this)

--- a/ast_mapper_class_402.ml
+++ b/ast_mapper_class_402.ml
@@ -1,4 +1,4 @@
-open Ast_402
+open Migrate_parsetree.Ast_402
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_402.mli
+++ b/ast_mapper_class_402.mli
@@ -1,4 +1,4 @@
-open Ast_402
+open Migrate_parsetree.Ast_402
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_403.ml
+++ b/ast_mapper_class_403.ml
@@ -1,4 +1,4 @@
-open Ast_403
+open Migrate_parsetree.Ast_403
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_403.mli
+++ b/ast_mapper_class_403.mli
@@ -1,4 +1,4 @@
-open Ast_403
+open Migrate_parsetree.Ast_403
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_404.ml
+++ b/ast_mapper_class_404.ml
@@ -1,4 +1,4 @@
-open Ast_404
+open Migrate_parsetree.Ast_404
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_404.mli
+++ b/ast_mapper_class_404.mli
@@ -1,4 +1,4 @@
-open Ast_404
+open Migrate_parsetree.Ast_404
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_405.ml
+++ b/ast_mapper_class_405.ml
@@ -1,4 +1,4 @@
-open Ast_405
+open Migrate_parsetree.Ast_405
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_405.mli
+++ b/ast_mapper_class_405.mli
@@ -1,4 +1,4 @@
-open Ast_405
+open Migrate_parsetree.Ast_405
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_406.ml
+++ b/ast_mapper_class_406.ml
@@ -1,4 +1,4 @@
-open Ast_406
+open Migrate_parsetree.Ast_406
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_406.mli
+++ b/ast_mapper_class_406.mli
@@ -1,4 +1,4 @@
-open Ast_406
+open Migrate_parsetree.Ast_406
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_407.ml
+++ b/ast_mapper_class_407.ml
@@ -1,4 +1,4 @@
-open Ast_407
+open Migrate_parsetree.Ast_407
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ast_mapper_class_407.mli
+++ b/ast_mapper_class_407.mli
@@ -1,4 +1,4 @@
-open Ast_407
+open Migrate_parsetree.Ast_407
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ppx_metaquot_402.ml
+++ b/ppx_metaquot_402.ml
@@ -1,4 +1,4 @@
-open Ast_402
+open Migrate_parsetree.Ast_402
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ppx_metaquot_403.ml
+++ b/ppx_metaquot_403.ml
@@ -1,4 +1,4 @@
-open Ast_403
+open Migrate_parsetree.Ast_403
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ppx_metaquot_404.ml
+++ b/ppx_metaquot_404.ml
@@ -1,4 +1,4 @@
-open Ast_404
+open Migrate_parsetree.Ast_404
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ppx_metaquot_405.ml
+++ b/ppx_metaquot_405.ml
@@ -1,4 +1,4 @@
-open Ast_405
+open Migrate_parsetree.Ast_405
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ppx_metaquot_406.ml
+++ b/ppx_metaquot_406.ml
@@ -1,4 +1,4 @@
-open Ast_406
+open Migrate_parsetree.Ast_406
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)

--- a/ppx_metaquot_407.ml
+++ b/ppx_metaquot_407.ml
@@ -1,4 +1,4 @@
-open Ast_407
+open Migrate_parsetree.Ast_407
 
 (*  This file is part of the ppx_tools package.  It is released  *)
 (*  under the terms of the MIT license (see LICENSE file).       *)


### PR DESCRIPTION
Since https://github.com/ocaml-ppx/ocaml-migrate-parsetree/commit/71b9d110709e05b928999b93f4cb9e6a3f77f332, building `ppx_tools_versioned` fails with errors like

```
File "ast_mapper_class_407.mli", line 1, characters 5-12:
1 | open Ast_407
         ^^^^^^^
Error (alert deprecated): module Ast_407
Access modules via the Migrate_parsetree toplevel module. Use Migrate_parsetree.Ast_407 instead.
```

This commit fixes that.

I'm also going to open a PR to opam-repository to constrain existing `ppx_tools_versioned` releases.

The `Migrate_parsetree._` module aliases were already present in OMP 1.0.1, so it doesn't look like we need a tighter lower constraint on it.

The commit also gets rid of some trailing whitespace because my editor is configured to do that, let me know if you want me to factor that out into a separate commit.